### PR TITLE
stop batch correction cell index scrambling, and retain raw if present

### DIFF
--- a/scgen/models/util.py
+++ b/scgen/models/util.py
@@ -301,7 +301,9 @@ def batch_removal(network, adata, batch_key="batch", cell_label_key="cell_type")
         corrected.var_names = adata.var_names.tolist()
         corrected = corrected[adata.obs_names]
         if adata.raw is not None:
-            corrected.raw = adata.raw.copy()
+            adata_raw = anndata.AnnData(X=adata.raw.X, var=adata.raw.var)
+            adata_raw.obs_names = adata.obs_names
+            corrected.raw = adata_raw
         return corrected
     else:
         all_not_shared_ann = anndata.AnnData.concatenate(*not_shared_ct, batch_key="concat_batch", index_unique=None)
@@ -313,7 +315,9 @@ def batch_removal(network, adata, batch_key="batch", cell_label_key="cell_type")
         corrected.var_names = adata.var_names.tolist()
         corrected = corrected[adata.obs_names]
         if adata.raw is not None:
-            corrected.raw = adata.raw.copy()
+            adata_raw = anndata.AnnData(X=adata.raw.X, var=adata.raw.var)
+            adata_raw.obs_names = adata.obs_names
+            corrected.raw = adata_raw
         return corrected
 
 

--- a/scgen/models/util.py
+++ b/scgen/models/util.py
@@ -292,24 +292,28 @@ def batch_removal(network, adata, batch_key="batch", cell_label_key="cell_type")
             batch_list[study].X = delta + batch_list[study].X
             temp_cell[batch_ind[study]].X = batch_list[study].X
         shared_ct.append(temp_cell)
-    all_shared_ann = anndata.AnnData.concatenate(*shared_ct, batch_key="concat_batch")
+    all_shared_ann = anndata.AnnData.concatenate(*shared_ct, batch_key="concat_batch", index_unique=None)
     if "concat_batch" in all_shared_ann.obs.columns:
         del all_shared_ann.obs["concat_batch"]
     if len(not_shared_ct) < 1:
         corrected = anndata.AnnData(network.reconstruct(all_shared_ann.X, use_data=True))
         corrected.obs = all_shared_ann.obs.copy(deep=True)
         corrected.var_names = adata.var_names.tolist()
-        corrected.obs_names = adata.obs_names.tolist()
+        corrected = corrected[adata.obs_names]
+        if adata.raw is not None:
+            corrected.raw = adata.raw.copy()
         return corrected
     else:
-        all_not_shared_ann = anndata.AnnData.concatenate(*not_shared_ct, batch_key="concat_batch")
-        all_corrected_data = anndata.AnnData.concatenate(all_shared_ann, all_not_shared_ann, batch_key="concat_batch")
+        all_not_shared_ann = anndata.AnnData.concatenate(*not_shared_ct, batch_key="concat_batch", index_unique=None)
+        all_corrected_data = anndata.AnnData.concatenate(all_shared_ann, all_not_shared_ann, batch_key="concat_batch",  index_unique=None)
         if "concat_batch" in all_shared_ann.obs.columns:
             del all_corrected_data.obs["concat_batch"]
         corrected = anndata.AnnData(network.reconstruct(all_corrected_data.X, use_data=True), )
         corrected.obs = pd.concat([all_shared_ann.obs, all_not_shared_ann.obs])
         corrected.var_names = adata.var_names.tolist()
-        corrected.obs_names = adata.obs_names.tolist()
+        corrected = corrected[adata.obs_names]
+        if adata.raw is not None:
+            corrected.raw = adata.raw.copy()
         return corrected
 
 


### PR DESCRIPTION
added `index_unique=None` to concatenation, sorted `corrected` on `adata.obs_names` and copy over `.raw` from the original object if it's not empty.