### PR TITLE
Allow to use custom datamodules for training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
   {include = "scgen"},
 ]
 readme = "README.md"
-version = "2.1.1"
+version = "2.1.2"
 
 [tool.poetry.dependencies]
 adjustText = "*"

--- a/scgen/_scgen.py
+++ b/scgen/_scgen.py
@@ -46,6 +46,8 @@ class SCGEN(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     >>> adata.obsm["X_scgen"] = vae.get_latent_representation()
     """
 
+    _module_cls = SCGENVAE
+
     def __init__(
         self,
         adata: AnnData,
@@ -57,14 +59,24 @@ class SCGEN(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
     ):
         super().__init__(adata)
 
-        self.module = SCGENVAE(
-            n_input=self.summary_stats.n_vars,
-            n_hidden=n_hidden,
-            n_latent=n_latent,
-            n_layers=n_layers,
-            dropout_rate=dropout_rate,
-            **model_kwargs,
-        )
+        self._module_kwargs = {
+            "n_hidden": n_hidden,
+            "n_latent": n_latent,
+            "n_layers": n_layers,
+            "dropout_rate": dropout_rate,
+            **model_kwargs
+        }
+        if self._module_init_on_train:
+            self.module = None
+        else:
+            self.module = SCGENVAE(
+                n_input=self.summary_stats.n_vars,
+                n_hidden=n_hidden,
+                n_latent=n_latent,
+                n_layers=n_layers,
+                dropout_rate=dropout_rate,
+                **model_kwargs,
+            )
         self._model_summary_string = (
             "SCGEN Model with the following params: \nn_hidden: {}, n_latent: {}, n_layers: {}, dropout_rate: "
             "{}"

--- a/scgen/_scgenvae.py
+++ b/scgen/_scgenvae.py
@@ -45,6 +45,7 @@ class SCGENVAE(BaseModuleClass):
         use_batch_norm: Literal["encoder", "decoder", "none", "both"] = "both",
         use_layer_norm: Literal["encoder", "decoder", "none", "both"] = "none",
         kl_weight: float = 0.00005,
+        **kwargs # needed when initilaized with a datamodule
     ):
         super().__init__()
         self.n_layers = n_layers


### PR DESCRIPTION
Uses https://github.com/scverse/scvi-tools/pull/2467

```python
model = scgen.SCGEN(adata=None)
model.train(datamodule=datamodule, ...) # or data_module=datamodule depending on scvi version
```